### PR TITLE
feat: Parser and ParserBytes

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -584,6 +584,7 @@ func TestImplementations(t *testing.T) {
 		TotalKeys:     11,
 		MaxKeyLen:     5,
 		MaxArrayLen:   5,
+		// MaxPathLen is not considered in this test
 	}
 	for _, tt := range []struct {
 		name string

--- a/bench_test.go
+++ b/bench_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	encodingjson "encoding/json"
 	"fmt"
-	"strconv"
 	"testing"
 
 	"github.com/romshark/jscan"
@@ -32,11 +31,19 @@ type Stats struct {
 	MaxKeyLen     int
 	MaxDepth      int
 	MaxArrayLen   int
-	MaxPathLen    int
 }
 
-func CalcStatsJscan(str []byte) (s Stats) {
-	if err := jscan.ScanBytes(
+// StackItem is used for manual stack management
+// (optimization to avoid recursion)
+type StackItem struct {
+	level int
+	key   string
+	index int
+	state int8
+}
+
+func CalcStatsJscan(parser *jscan.ParserBytes, str []byte) (s Stats) {
+	if err := parser.Scan(
 		jscan.Options{},
 		str,
 		func(i *jscan.IteratorBytes) (err bool) {
@@ -74,174 +81,99 @@ func CalcStatsJscan(str []byte) (s Stats) {
 	return
 }
 
-func CalcStatsJscanWithPath(str []byte) (s Stats) {
-	if err := jscan.ScanBytes(jscan.Options{
-		CachePath:  true,
-		EscapePath: false,
-	}, str, func(i *jscan.IteratorBytes) (err bool) {
-		if l := i.KeyEnd - i.KeyStart; l > 0 {
-			s.TotalKeys++
-			if l > s.MaxKeyLen {
-				s.MaxKeyLen = l
-			}
-		}
-		switch i.ValueType {
-		case jscan.ValueTypeObject:
-			s.TotalObjects++
-		case jscan.ValueTypeArray:
-			s.TotalArrays++
-		case jscan.ValueTypeNull:
-			s.TotalNulls++
-		case jscan.ValueTypeFalse, jscan.ValueTypeTrue:
-			s.TotalBooleans++
-		case jscan.ValueTypeNumber:
-			s.TotalNumbers++
-		case jscan.ValueTypeString:
-			s.TotalStrings++
-		}
-		if i.Level > s.MaxDepth {
-			s.MaxDepth = i.Level
-		}
-		if l := i.ArrayIndex + 1; l > s.MaxArrayLen {
-			s.MaxArrayLen = l
-		}
-		i.ViewPath(func(p []byte) {
-			if l := len(p); l > s.MaxPathLen {
-				s.MaxPathLen = l
-			}
-		})
-		return false
-	}); err.IsErr() {
-		panic(fmt.Errorf("unexpected error: %s", err))
-	}
-	return
+type JsoniterIterator struct {
+	stack    []StackItem
+	iterator *jsoniter.Iterator
 }
 
-func CalcStatsJsoniter(str []byte) (s Stats) {
-	i := jsoniter.ParseBytes(jsoniter.ConfigDefault, str)
-	var readValue func(lv int, k string, ai int, i *jsoniter.Iterator)
-	readValue = func(
-		level int,
-		key string,
-		arrIndex int,
-		i *jsoniter.Iterator,
-	) {
-		if level > s.MaxDepth {
-			s.MaxDepth = level
+func NewJsoniterIterator() *JsoniterIterator {
+	return &JsoniterIterator{
+		stack:    make([]StackItem, 0, 256),
+		iterator: jsoniter.NewIterator(jsoniter.ConfigFastest),
+	}
+}
+
+func CalcStatsJsoniter(p *JsoniterIterator, str []byte) (s Stats) {
+	i := p.iterator.ResetBytes(str)
+	p.stack = p.stack[:0] // Reset stack
+	p.stack = append(p.stack, StackItem{level: 0, index: 0})
+
+	for len(p.stack) > 0 {
+		t := p.stack[len(p.stack)-1]
+		p.stack = p.stack[:len(p.stack)-1]
+
+		if t.level > s.MaxDepth {
+			s.MaxDepth = t.level
 		}
-		if l := len(key); l > 0 {
+		if l := len(t.key); l > 0 {
 			s.TotalKeys++
 			if l > s.MaxKeyLen {
 				s.MaxKeyLen = l
 			}
 		}
-		switch i.WhatIsNext() {
-		case jsoniter.StringValue:
-			i.ReadString()
-			s.TotalStrings++
-		case jsoniter.NumberValue:
-			i.ReadNumber()
-			s.TotalNumbers++
-		case jsoniter.NilValue:
-			i.ReadNil()
-			s.TotalNulls++
-		case jsoniter.BoolValue:
-			i.ReadBool()
-			s.TotalBooleans++
-		case jsoniter.ArrayValue:
-			s.TotalArrays++
-			l := level + 1
-			index := 0
-			for e := i.ReadArray(); e; e = i.ReadArray() {
-				readValue(l, "", index, i)
-				index++
-				if index > s.MaxArrayLen {
-					s.MaxArrayLen = index
+
+		switch t.state {
+		case 0:
+			switch i.WhatIsNext() {
+			case jsoniter.StringValue:
+				s.TotalStrings++
+				i.ReadString()
+			case jsoniter.NumberValue:
+				s.TotalNumbers++
+				i.ReadNumber()
+			case jsoniter.NilValue:
+				s.TotalNulls++
+				i.ReadNil()
+			case jsoniter.BoolValue:
+				s.TotalBooleans++
+				i.ReadBool()
+			case jsoniter.ArrayValue:
+				s.TotalArrays++
+				hasMore := i.ReadArray()
+				if !hasMore {
+					continue
+				}
+				t.level++
+				p.stack = append(p.stack, StackItem{
+					level: t.level, state: 1, index: 0,
+				})
+				p.stack = append(p.stack, StackItem{
+					level: t.level, state: 0, index: 0,
+				})
+			case jsoniter.ObjectValue:
+				s.TotalObjects++
+				t.level++
+				if key := i.ReadObject(); key != "" {
+					p.stack = append(p.stack, StackItem{
+						level: t.level, state: 2,
+					})
+					p.stack = append(p.stack, StackItem{
+						level: t.level, key: key,
+					})
 				}
 			}
-		case jsoniter.ObjectValue:
-			s.TotalObjects++
-			l := level + 1
-			for f := i.ReadObject(); f != ""; f = i.ReadObject() {
-				readValue(l, f, -1, i)
+		case 1:
+			if i.ReadArray() {
+				p.stack = append(p.stack, StackItem{
+					level: t.level, state: 1, index: t.index + 1,
+				})
+				p.stack = append(p.stack, StackItem{level: t.level})
+			} else if t.index+1 > s.MaxArrayLen {
+				s.MaxArrayLen = t.index + 1
+			}
+		case 2:
+			if key := i.ReadObject(); key != "" {
+				p.stack = append(p.stack, StackItem{level: t.level, state: 2})
+				p.stack = append(p.stack, StackItem{level: t.level, key: key})
 			}
 		}
 	}
-	readValue(0, "", -1, i)
-	return
+
+	return s
 }
 
-func CalcStatsJsoniterWithPath(str []byte) (s Stats) {
-	i := jsoniter.ParseBytes(jsoniter.ConfigDefault, str)
-	var readValue func(lv int, k, p string, ai int, i *jsoniter.Iterator)
-	readValue = func(
-		level int,
-		key, path string,
-		arrIndex int,
-		i *jsoniter.Iterator,
-	) {
-		if level > s.MaxDepth {
-			s.MaxDepth = level
-		}
-		if l := len(key); l > 0 {
-			s.TotalKeys++
-			if l > s.MaxKeyLen {
-				s.MaxKeyLen = l
-			}
-		}
-		if key != "" {
-			if path != "" {
-				path += "." + key
-			} else {
-				path += key
-			}
-		} else if arrIndex > -1 {
-			path += "[" + strconv.Itoa(arrIndex) + "]"
-		}
-		if l := len(path); l > s.MaxPathLen {
-			s.MaxPathLen = l
-		}
-		switch i.WhatIsNext() {
-		case jsoniter.StringValue:
-			i.ReadString()
-			s.TotalStrings++
-		case jsoniter.NumberValue:
-			i.ReadNumber()
-			s.TotalNumbers++
-		case jsoniter.NilValue:
-			i.ReadNil()
-			s.TotalNulls++
-		case jsoniter.BoolValue:
-			i.ReadBool()
-			s.TotalBooleans++
-		case jsoniter.ArrayValue:
-			s.TotalArrays++
-			l := level + 1
-			index := 0
-			for e := i.ReadArray(); e; e = i.ReadArray() {
-				readValue(l, "", path, index, i)
-				index++
-				if index > s.MaxArrayLen {
-					s.MaxArrayLen = index
-				}
-			}
-		case jsoniter.ObjectValue:
-			s.TotalObjects++
-			l := level + 1
-			for f := i.ReadObject(); f != ""; f = i.ReadObject() {
-				readValue(l, f, path, -1, i)
-			}
-		}
-	}
-	readValue(0, "", "", -1, i)
-	return
-}
-
-func CalcStatsGofasterJx(str []byte) (s Stats) {
-	d := gofasterjx.GetDecoder()
-	defer gofasterjx.PutDecoder(d)
-	d.ResetBytes(str)
-
+func CalcStatsGofasterJx(parser *gofasterjx.Decoder, str []byte) (s Stats) {
+	parser.ResetBytes(str)
 	var jxParseValue func(lv int, k []byte, ai int) error
 	jxParseValue = func(
 		level int,
@@ -258,31 +190,31 @@ func CalcStatsGofasterJx(str []byte) (s Stats) {
 			}
 		}
 
-		switch d.Next() {
+		switch parser.Next() {
 		case gofasterjx.String:
 			s.TotalStrings++
-			if err := d.Skip(); err != nil {
+			if err := parser.Skip(); err != nil {
 				return err
 			}
 		case gofasterjx.Null:
 			s.TotalNulls++
-			if err := d.Skip(); err != nil {
+			if err := parser.Skip(); err != nil {
 				return err
 			}
 		case gofasterjx.Bool:
 			s.TotalBooleans++
-			if err := d.Skip(); err != nil {
+			if err := parser.Skip(); err != nil {
 				return err
 			}
 		case gofasterjx.Number:
 			s.TotalNumbers++
-			if err := d.Skip(); err != nil {
+			if err := parser.Skip(); err != nil {
 				return err
 			}
 		case gofasterjx.Array:
 			s.TotalArrays++
 			i := 0
-			if err := d.Arr(func(d *gofasterjx.Decoder) error {
+			if err := parser.Arr(func(d *gofasterjx.Decoder) error {
 				if err := jxParseValue(level+1, nil, i); err != nil {
 					return err
 				}
@@ -296,7 +228,7 @@ func CalcStatsGofasterJx(str []byte) (s Stats) {
 			}
 		case gofasterjx.Object:
 			s.TotalObjects++
-			if err := d.ObjBytes(func(d *gofasterjx.Decoder, key []byte) error {
+			if err := parser.ObjBytes(func(d *gofasterjx.Decoder, key []byte) error {
 				return jxParseValue(level+1, key, -1)
 			}); err != nil {
 				return err
@@ -310,100 +242,8 @@ func CalcStatsGofasterJx(str []byte) (s Stats) {
 	return
 }
 
-func CalcStatsGofasterJxWithPath(str []byte) (s Stats) {
-	d := gofasterjx.GetDecoder()
-	defer gofasterjx.PutDecoder(d)
-	d.ResetBytes(str)
-
-	var jxParseValue func(lv int, k, path string, ai int) error
-	jxParseValue = func(
-		level int,
-		key, path string,
-		arrayIndex int,
-	) error {
-		if level > s.MaxDepth {
-			s.MaxDepth = level
-		}
-		if l := len(key); l > 0 {
-			s.TotalKeys++
-			if l > s.MaxKeyLen {
-				s.MaxKeyLen = l
-			}
-		}
-		if key != "" {
-			if path != "" {
-				path += "." + key
-			} else {
-				path += key
-			}
-		} else if arrayIndex > -1 {
-			path += "[" + strconv.Itoa(arrayIndex) + "]"
-		}
-		if l := len(path); l > s.MaxPathLen {
-			s.MaxPathLen = l
-		}
-
-		switch d.Next() {
-		case gofasterjx.String:
-			s.TotalStrings++
-			_, err := d.Str()
-			if err != nil {
-				return err
-			}
-		case gofasterjx.Null:
-			s.TotalNulls++
-			if err := d.Null(); err != nil {
-				return err
-			}
-		case gofasterjx.Bool:
-			s.TotalBooleans++
-			_, err := d.Bool()
-			if err != nil {
-				return err
-			}
-		case gofasterjx.Number:
-			s.TotalNumbers++
-			_, err := d.Num()
-			if err != nil {
-				return err
-			}
-		case gofasterjx.Array:
-			s.TotalArrays++
-			i := 0
-			if err := d.Arr(func(d *gofasterjx.Decoder) error {
-				if err := jxParseValue(level+1, "", path, i); err != nil {
-					return err
-				}
-				i++
-				if i > s.MaxArrayLen {
-					s.MaxArrayLen = i
-				}
-				return nil
-			}); err != nil {
-				return err
-			}
-		case gofasterjx.Object:
-			s.TotalObjects++
-			if err := d.Obj(func(d *gofasterjx.Decoder, key string) error {
-				return jxParseValue(level+1, key, path, -1)
-			}); err != nil {
-				return err
-			}
-		}
-		return nil
-	}
-	if err := jxParseValue(0, "", "", -1); err != nil {
-		panic(err)
-	}
-	return
-}
-
-var valyalafastjsonPool = new(valyalafastjson.ParserPool)
-
-func CalcStatsValyalaFastjson(str []byte) (s Stats) {
-	p := valyalafastjsonPool.Get()
-	defer valyalafastjsonPool.Put(p)
-	v, err := p.ParseBytes(str)
+func CalcStatsValyalaFastjson(parser *valyalafastjson.Parser, str []byte) (s Stats) {
+	v, err := parser.ParseBytes(str)
 	if err != nil {
 		panic(err)
 	}
@@ -477,98 +317,6 @@ func CalcStatsValyalaFastjson(str []byte) (s Stats) {
 	return
 }
 
-func CalcStatsValyalaFastjsonWithPath(str []byte) (s Stats) {
-	p := valyalafastjsonPool.Get()
-	defer valyalafastjsonPool.Put(p)
-	v, err := p.ParseBytes(str)
-	if err != nil {
-		panic(err)
-	}
-
-	var parseValue func(v *valyalafastjson.Value, lv int, k, p []byte, a int) error
-	parseValue = func(
-		v *valyalafastjson.Value,
-		level int,
-		key, path []byte,
-		arrayIndex int,
-	) error {
-		if level > s.MaxDepth {
-			s.MaxDepth = level
-		}
-		if l := len(key); l > 0 && arrayIndex == -1 {
-			s.TotalKeys++
-			if l > s.MaxKeyLen {
-				s.MaxKeyLen = l
-			}
-		}
-		if key != nil && arrayIndex < 0 {
-			if path != nil {
-				path = append(path, '.')
-				path = append(path, key...)
-			} else {
-				path = append(path, key...)
-			}
-		} else if arrayIndex > -1 {
-			path = append(path, '[')
-			path = strconv.AppendInt(path, int64(arrayIndex), 10)
-			path = append(path, ']')
-		}
-		if l := len(path); l > s.MaxPathLen {
-			s.MaxPathLen = l
-		}
-
-		switch v.Type() {
-		case valyalafastjson.TypeString:
-			s.TotalStrings++
-
-		case valyalafastjson.TypeNull:
-			s.TotalNulls++
-
-		case valyalafastjson.TypeTrue, valyalafastjson.TypeFalse:
-			s.TotalBooleans++
-
-		case valyalafastjson.TypeNumber:
-			s.TotalNumbers++
-
-		case valyalafastjson.TypeArray:
-			s.TotalArrays++
-			values, err := v.Array()
-			if err != nil {
-				return err
-			}
-			lv := level + 1
-			for i, v := range values {
-				if err := parseValue(v, lv, key, path, i); err != nil {
-					return err
-				}
-				if i := i + 1; i > s.MaxArrayLen {
-					s.MaxArrayLen = i
-				}
-			}
-			return nil
-
-		case valyalafastjson.TypeObject:
-			s.TotalObjects++
-			o, err := v.Object()
-			if err != nil {
-				return err
-			}
-			lv := level + 1
-			o.Visit(func(key []byte, v *valyalafastjson.Value) {
-				if err = parseValue(v, lv, key, path, -1); err != nil {
-					return
-				}
-			})
-			return nil
-		}
-		return nil
-	}
-	if err := parseValue(v, 0, nil, nil, -1); err != nil {
-		panic(err)
-	}
-	return
-}
-
 func TestImplementations(t *testing.T) {
 	const input = `{"s":"value","t":true,"f":false,"0":null,"n":-9.123e3,` +
 		`"o0":{},"a0":[],"o":{"k":"\"v\"",` +
@@ -584,53 +332,28 @@ func TestImplementations(t *testing.T) {
 		TotalKeys:     11,
 		MaxKeyLen:     5,
 		MaxArrayLen:   5,
-		// MaxPathLen is not considered in this test
 	}
-	for _, tt := range []struct {
-		name string
-		fn   func([]byte) Stats
-	}{
-		{name: "jscan", fn: CalcStatsJscan},
-		{name: "jsoniter", fn: CalcStatsJsoniter},
-		{name: "gofaster-jx", fn: CalcStatsGofasterJx},
-		{name: "valyala-fastjson", fn: CalcStatsValyalaFastjson},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, expect, tt.fn([]byte(input)))
-		})
-	}
-}
 
-func TestImplementationsWithPath(t *testing.T) {
-	const input = `{"s":"value","t":true,"f":false,"0":null,"n":-9.123e3,` +
-		`"o0":{},"a0":[],"o":{"k":"\"v\"",` +
-		`"a":[true,null,"item",-67.02e9,["foo"]]},"[abc]":[0]}`
-	expect := Stats{
-		TotalStrings:  4,
-		TotalNulls:    2,
-		TotalBooleans: 3,
-		TotalNumbers:  3,
-		TotalObjects:  3,
-		TotalArrays:   4,
-		MaxDepth:      4,
-		TotalKeys:     11,
-		MaxKeyLen:     5,
-		MaxArrayLen:   5,
-		MaxPathLen:    9,
-	}
-	for _, tt := range []struct {
-		name string
-		fn   func([]byte) Stats
-	}{
-		{name: "jscan", fn: CalcStatsJscanWithPath},
-		{name: "jsoniter", fn: CalcStatsJsoniterWithPath},
-		{name: "gofaster-jx", fn: CalcStatsGofasterJxWithPath},
-		{name: "valyala-fastjson", fn: CalcStatsValyalaFastjsonWithPath},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, expect, tt.fn([]byte(input)))
-		})
-	}
+	t.Run("jscan", func(t *testing.T) {
+		p := jscan.NewBytes(64)
+		a := CalcStatsJscan(p, []byte(input))
+		require.Equal(t, expect, a)
+	})
+	t.Run("jsoniter", func(t *testing.T) {
+		p := NewJsoniterIterator()
+		a := CalcStatsJsoniter(p, []byte(input))
+		require.Equal(t, expect, a)
+	})
+	t.Run("gofaster-jx", func(t *testing.T) {
+		p := new(gofasterjx.Decoder)
+		a := CalcStatsGofasterJx(p, []byte(input))
+		require.Equal(t, expect, a)
+	})
+	t.Run("valyala-fastjson", func(t *testing.T) {
+		p := &valyalafastjson.Parser{}
+		a := CalcStatsValyalaFastjson(p, []byte(input))
+		require.Equal(t, expect, a)
+	})
 }
 
 var gs Stats
@@ -665,62 +388,47 @@ var jsonArrayStr1024 []byte
 func BenchmarkCalcStats(b *testing.B) {
 	for _, bb := range []struct {
 		name string
-		fn   func([]byte) Stats
+		json []byte
 	}{
-		{
-			name: "jscan",
-			fn:   CalcStatsJscan,
-		},
-		{
-			name: "jsoniter",
-			fn:   CalcStatsJsoniter,
-		},
-		{
-			name: "gofaster-jx",
-			fn:   CalcStatsGofasterJx,
-		},
-		{
-			name: "valyala-fastjson",
-			fn:   CalcStatsValyalaFastjson,
-		},
-		{
-			name: "jscan_withpath",
-			fn:   CalcStatsJscanWithPath,
-		},
-		{
-			name: "jsoniter_withpath",
-			fn:   CalcStatsJsoniterWithPath,
-		},
-		{
-			name: "gofaster-jx_withpath",
-			fn:   CalcStatsGofasterJxWithPath,
-		},
-		{
-			name: "valyala-fastjson_withpath",
-			fn:   CalcStatsValyalaFastjsonWithPath,
-		},
+		{"miniscule", jsonMiniscule},
+		{"tiny", jsonTiny},
+		{"small", jsonSmall},
+		{"large", jsonLarge},
+		{"escaped", jsonEscaped},
+		{"array_int_1024", jsonArrayInt1024},
+		{"array_dec_1024", jsonArrayDec1024},
+		{"array_nullbool_1024", jsonArrayNullBool1024},
+		{"array_str_1024", jsonArrayStr1024},
 	} {
 		b.Run(bb.name, func(b *testing.B) {
-			for _, b2 := range []struct {
-				name string
-				json []byte
-			}{
-				{"miniscule", jsonMiniscule},
-				{"tiny", jsonTiny},
-				{"small", jsonSmall},
-				{"large", jsonLarge},
-				{"escaped", jsonEscaped},
-				{"array_int_1024", jsonArrayInt1024},
-				{"array_dec_1024", jsonArrayDec1024},
-				{"array_nullbool_1024", jsonArrayNullBool1024},
-				{"array_str_1024", jsonArrayStr1024},
-			} {
-				b.Run(b2.name, func(b *testing.B) {
-					for i := 0; i < b.N; i++ {
-						gs = bb.fn(b2.json)
-					}
-				})
-			}
+			b.Run("jscan", func(b *testing.B) {
+				p := jscan.NewBytes(64)
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					gs = CalcStatsJscan(p, bb.json)
+				}
+			})
+			b.Run("jsoniter", func(b *testing.B) {
+				p := NewJsoniterIterator()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					gs = CalcStatsJsoniter(p, bb.json)
+				}
+			})
+			b.Run("gofaster-jx", func(b *testing.B) {
+				p := new(gofasterjx.Decoder)
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					gs = CalcStatsGofasterJx(p, bb.json)
+				}
+			})
+			b.Run("valyala-fastjson", func(b *testing.B) {
+				p := new(valyalafastjson.Parser)
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					gs = CalcStatsValyalaFastjson(p, bb.json)
+				}
+			})
 		})
 	}
 }

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -38,24 +38,26 @@ func FuzzValid(f *testing.F) {
 			jscanBytes       = jscan.ValidBytes([]byte(data))
 			jscanStr         = jscan.Valid(data)
 		)
-		switch {
-		case std != jscanStr:
-			t.Fatalf(
+		if std != jscanStr {
+			t.Errorf(
 				`Valid(%q): %t (std) != %t (jscanStr)`,
 				data, std, jscanStr,
 			)
-		case std != jscanBytes:
-			t.Fatalf(
+		}
+		if std != jscanBytes {
+			t.Errorf(
 				`Valid(%q): %t (std) != %t (jscanBytes)`,
 				data, std, jscanBytes,
 			)
-		case std != jscanParserStr:
-			t.Fatalf(
+		}
+		if std != jscanParserStr {
+			t.Errorf(
 				`Valid(%q): %t (std) != %t (jscanParserStr)`,
 				data, std, jscanParserStr,
 			)
-		case std != jscanParserBytes:
-			t.Fatalf(
+		}
+		if std != jscanParserBytes {
+			t.Errorf(
 				`Valid(%q): %t (std) != %t (jscanParserBytes)`,
 				data, std, jscanParserBytes,
 			)

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -1,11 +1,15 @@
-package jscan
+package jscan_test
 
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/romshark/jscan"
 )
 
 func FuzzValid(f *testing.F) {
+	p, pb := jscan.New(64), jscan.NewBytes(64)
+
 	for _, s := range []string{
 		``,
 		`0`,
@@ -28,19 +32,32 @@ func FuzzValid(f *testing.F) {
 	}
 	f.Fuzz(func(t *testing.T, data string) {
 		var (
-			std        = json.Valid([]byte(data))
-			jscanBytes = ValidBytes([]byte(data))
-			jscanStr   = Valid(data)
+			std              = json.Valid([]byte(data))
+			jscanParserBytes = pb.Valid([]byte(data))
+			jscanParserStr   = p.Valid(data)
+			jscanBytes       = jscan.ValidBytes([]byte(data))
+			jscanStr         = jscan.Valid(data)
 		)
-		if std != jscanStr {
+		switch {
+		case std != jscanStr:
 			t.Fatalf(
 				`Valid(%q): %t (std) != %t (jscanStr)`,
 				data, std, jscanStr,
 			)
-		} else if std != jscanBytes {
+		case std != jscanBytes:
 			t.Fatalf(
 				`Valid(%q): %t (std) != %t (jscanBytes)`,
 				data, std, jscanBytes,
+			)
+		case std != jscanParserStr:
+			t.Fatalf(
+				`Valid(%q): %t (std) != %t (jscanParserStr)`,
+				data, std, jscanParserStr,
+			)
+		case std != jscanParserBytes:
+			t.Fatalf(
+				`Valid(%q): %t (std) != %t (jscanParserBytes)`,
+				data, std, jscanParserBytes,
 			)
 		}
 	})

--- a/jscan.go
+++ b/jscan.go
@@ -125,8 +125,9 @@ func (i *Iterator) ViewPath(fn func(p []byte)) {
 
 var itrPool = sync.Pool{
 	New: func() any {
-		i := &Iterator{st: stack.New(64)}
-		return i
+		return &Iterator{
+			st: stack.New(64),
+		}
 	},
 }
 

--- a/jscan.go
+++ b/jscan.go
@@ -12,7 +12,7 @@ import (
 	"github.com/romshark/jscan/internal/strfind"
 )
 
-// Iterator provides access to the recently scanned value.
+// Iterator provides read-only access to the recently scanned value.
 type Iterator struct {
 	st         *stack.Stack
 	src        string
@@ -78,11 +78,11 @@ func (i *Iterator) Path() (s string) {
 	return
 }
 
-// ViewPath calls fn and provides the stringified path.
+// ViewPath calls fn and provides the stringified path for read-only.
 //
-// WARNING: do not use or alias p after fn returns!
-// Only viewing or copying are considered safe!
-// Use (*Iterator).Path instead for a safer and more convenient API.
+// WARNING: do not use or alias p after fn returns, copy
+// instead to avoid undefined behavior!
+// Consider using (*Iterator).Path instead if you need a copy.
 func (i *Iterator) ViewPath(fn func(p []byte)) {
 	if len(i.cachedPath) > 0 {
 		// The path is already cached
@@ -153,13 +153,13 @@ func (p *Parser) Validate(s string) Error {
 }
 
 // Scan calls fn for every scanned value including objects and arrays.
-// Scan returns true if there was an error or if fn returned true,
-// otherwise it returns false.
-// If cachePath == true then paths are generated and cached on the fly
-// reducing their performance penalty.
+// If Options.CachePath == true then paths are generated and cached on the fly
+// significantly improving performance of (*Iterator).Path and (*Iterator).ViewPath,
+// otherwise paths are computed when either of the methods are called.
 //
-// WARNING: Fields exported by *Iterator in fn must not be mutated!
-// Do not use or alias *Iterator after fn returns!
+// WARNING: Fields exported by *Iterator provided in fn must not be mutated!
+// Do not use or alias *Iterator after fn returns,
+// copy instead to avoid undefined behavior!
 func (p *Parser) Scan(
 	o Options,
 	s string,
@@ -175,8 +175,9 @@ func (p *Parser) Scan(
 // and no error is returned.
 // If escapePath then all dots and square brackets are expected to be escaped.
 //
-// WARNING: Fields exported by *Iterator in fn must not be mutated!
-// Do not use or alias *Iterator after fn returns!
+// WARNING: Fields exported by *Iterator provided in fn must not be mutated!
+// Do not use or alias *Iterator after fn returns,
+// copy instead to avoid undefined behavior!
 func (p *Parser) Get(
 	s, path string,
 	escapePath bool,
@@ -234,13 +235,13 @@ func Validate(s string) Error {
 }
 
 // Scan calls fn for every scanned value including objects and arrays.
-// Scan returns true if there was an error or if fn returned true,
-// otherwise it returns false.
-// If cachePath == true then paths are generated and cached on the fly
-// reducing their performance penalty.
+// If Options.CachePath == true then paths are generated and cached on the fly
+// significantly improving performance of (*Iterator).Path and (*Iterator).ViewPath,
+// otherwise paths are computed when either of the methods are called.
 //
 // WARNING: Fields exported by *Iterator provided in fn must not be mutated!
-// Do not use or alias *Iterator after fn returns!
+// Do not use or alias *Iterator after fn returns,
+// copy instead to avoid undefined behavior!
 func Scan(
 	o Options,
 	s string,
@@ -258,8 +259,9 @@ func Scan(
 // and no error is returned.
 // If escapePath then all dots and square brackets are expected to be escaped.
 //
-// WARNING: Fields exported by *Iterator in fn must not be mutated!
-// Do not use or alias *Iterator after fn returns!
+// WARNING: Fields exported by *Iterator provided in fn must not be mutated!
+// Do not use or alias *Iterator after fn returns,
+// copy instead to avoid undefined behavior!
 func Get(
 	s, path string,
 	escapePath bool,

--- a/jscan.go
+++ b/jscan.go
@@ -279,15 +279,9 @@ func (i *Iterator) get(s, path string, escapePath bool, fn func(*Iterator)) Erro
 		EscapePath: escapePath,
 	}, s, func(i *Iterator) (err bool) {
 		i.ViewPath(func(p []byte) {
-			if len(p) != len(path) {
+			if string(p) != path {
 				return
 			}
-			for i := range p {
-				if p[i] != path[i] {
-					return
-				}
-			}
-
 			fn(i)
 			err = true
 		})

--- a/jscan_bytes.go
+++ b/jscan_bytes.go
@@ -268,7 +268,6 @@ func (i *IteratorBytes) get(
 	fn func(*IteratorBytes),
 ) ErrorBytes {
 	i.src, i.escapePath = s, escapePath
-	defer i.clear()
 	err := i.scan(Options{
 		CachePath:  true,
 		EscapePath: escapePath,

--- a/jscan_bytes.go
+++ b/jscan_bytes.go
@@ -122,6 +122,7 @@ var itrPoolBytes = sync.Pool{
 
 type ParserBytes struct{ i *IteratorBytes }
 
+// NewBytes creates a new parser instance.
 func NewBytes(stackCapacity int) *ParserBytes {
 	return &ParserBytes{
 		i: &IteratorBytes{

--- a/jscan_bytes.go
+++ b/jscan_bytes.go
@@ -114,8 +114,9 @@ func (i *IteratorBytes) ViewPath(fn func(p []byte)) {
 
 var itrPoolBytes = sync.Pool{
 	New: func() any {
-		i := &IteratorBytes{st: stack.New(64)}
-		return i
+		return &IteratorBytes{
+			st: stack.New(64),
+		}
 	},
 }
 

--- a/jscan_bytes.go
+++ b/jscan_bytes.go
@@ -450,12 +450,14 @@ func (i *IteratorBytes) validate(s []byte) ErrorBytes {
 			} else {
 				// Key
 				if i.expect != expectKey && i.expect != expectKeyOrObjTerm {
+					i.ValueStart--
 					return i.getError(ErrorCodeUnexpectedToken)
 				}
 				i.expect = expectVal
 
 				i.KeyStart, i.KeyEnd = i.ValueStart, i.ValueEnd
-				if i.ValueEnd > len(s) {
+				i.ValueStart = i.ValueEnd + 1
+				if i.ValueStart >= len(s) {
 					return i.getError(ErrorCodeUnexpectedEOF)
 				}
 				if x, err := i.parseColumn(s[i.ValueStart:]); err > 0 {
@@ -759,7 +761,7 @@ func (i *IteratorBytes) scanNoCache(
 
 				i.KeyStart, i.KeyEnd = i.ValueStart, i.ValueEnd
 				i.ValueStart = i.ValueEnd + 1
-				if i.ValueEnd > len(s) {
+				if i.ValueStart >= len(s) {
 					return i.getError(ErrorCodeUnexpectedEOF)
 				}
 				if x, err := i.parseColumn(s[i.ValueStart:]); err > 0 {
@@ -1076,7 +1078,7 @@ func (i *IteratorBytes) scanWithCachedPath(
 
 				i.KeyStart, i.KeyEnd = i.ValueStart, i.ValueEnd
 				i.ValueStart = i.ValueEnd + 1
-				if i.ValueEnd > len(s) {
+				if i.ValueStart >= len(s) {
 					return i.getError(ErrorCodeUnexpectedEOF)
 				}
 				if x, err := i.parseColumn(s[i.ValueStart:]); err > 0 {
@@ -1186,7 +1188,7 @@ func (i *IteratorBytes) scanWithCachedPath(
 }
 
 func (i *IteratorBytes) parseColumn(s []byte) (index int, err ErrorCode) {
-	if len(s) > 0 && s[0] == ':' {
+	if s[0] == ':' {
 		return 0, 0
 	}
 	for j, c := range s {

--- a/jscan_bytes.go
+++ b/jscan_bytes.go
@@ -1,7 +1,6 @@
 package jscan
 
 import (
-	"bytes"
 	"strconv"
 	"sync"
 	"unicode/utf8"
@@ -273,10 +272,9 @@ func (i *IteratorBytes) get(
 		EscapePath: escapePath,
 	}, s, func(i *IteratorBytes) (err bool) {
 		i.ViewPath(func(p []byte) {
-			if !bytes.Equal(p, path) {
+			if string(p) != string(path) {
 				return
 			}
-
 			fn(i)
 			err = true
 		})

--- a/jscan_test.go
+++ b/jscan_test.go
@@ -55,6 +55,13 @@ func testStrictOK(
 	t.Run("ParserBytesValid", func(t *testing.T) {
 		require.True(t, pb.Valid(input))
 	})
+	t.Run("ParserValidate", func(t *testing.T) {
+		p := jscan.New(64)
+		require.False(t, p.Validate(string(input)).IsErr())
+	})
+	t.Run("ParserBytesValidate", func(t *testing.T) {
+		require.False(t, pb.Validate(input).IsErr())
+	})
 	t.Run("ParserScan", func(t *testing.T) {
 		err := p.Scan(
 			jscan.Options{},
@@ -94,6 +101,12 @@ func testStrictOK(
 	})
 	t.Run("ValidBytes", func(t *testing.T) {
 		require.True(t, jscan.ValidBytes(input))
+	})
+	t.Run("Validate", func(t *testing.T) {
+		require.False(t, jscan.Validate(string(input)).IsErr())
+	})
+	t.Run("ValidateBytes", func(t *testing.T) {
+		require.False(t, jscan.ValidateBytes(input).IsErr())
 	})
 	t.Run("Scan", func(t *testing.T) {
 		err := jscan.Scan(

--- a/jscan_test.go
+++ b/jscan_test.go
@@ -975,6 +975,41 @@ func TestScanError(t *testing.T) {
 			expect: `error at index 5: unexpected EOF`,
 		},
 		{
+			name:   `illegal char in beginning`,
+			input:  string(byte(0x1F)) + "0",
+			expect: `error at index 0 (0x1f): illegal control character`,
+		},
+		{
+			name:   `illegal char in beginning after spaces`,
+			input:  " \n" + string(byte(0x1F)) + "0",
+			expect: `error at index 2 (0x1f): illegal control character`,
+		},
+		{
+			name:   `illegal char in beginning after comma in array`,
+			input:  `[0,` + string(byte(0x1F)) + `]`,
+			expect: `error at index 3 (0x1f): illegal control character`,
+		},
+		{
+			name:   `illegal char after key`,
+			input:  `{"x"` + string(byte(0x1F)) + `:0}`,
+			expect: `error at index 4 (0x1f): illegal control character`,
+		},
+		{
+			name:   `illegal char after key column`,
+			input:  `{"x":` + string(byte(0x1F)) + `:0}`,
+			expect: `error at index 5 (0x1f): illegal control character`,
+		},
+		{
+			name:   `illegal char in string`,
+			input:  `["x` + string(byte(0x1F)) + `"]`,
+			expect: `error at index 3 (0x1f): illegal control character`,
+		},
+		{
+			name:   `illegal char after value`,
+			input:  `["x" ` + string(byte(0x1F)) + `"]`,
+			expect: `error at index 5 (0x1f): illegal control character`,
+		},
+		{
 			name:   `missing column`,
 			input:  `{"key"}`,
 			expect: `error at index 6 ('}'): unexpected token`,

--- a/jscan_test.go
+++ b/jscan_test.go
@@ -975,6 +975,11 @@ func TestScanError(t *testing.T) {
 			expect: `error at index 5: unexpected EOF`,
 		},
 		{
+			name:   "EOF after key",
+			input:  `{"x"`,
+			expect: `error at index 4: unexpected EOF`,
+		},
+		{
 			name:   `illegal char in beginning`,
 			input:  string(byte(0x1F)) + "0",
 			expect: `error at index 0 (0x1f): illegal control character`,


### PR DESCRIPTION
feat: Add new types `Parser` and `ParserBytes` to allow direct parser instantiation bypassing `sync.Pool`.
fix: Avoid keeping reference to the input `string`/`[]byte` after `scan` returned.