### PR TITLE
PR to #21

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ func main() {
 		]
 	}`
 
-	err := jscan.Scan(j, func(i *jscan.Iterator[string]) (err bool) {
+	err := jscan.Scan(j, func(i *jscan.Iterator[string]) (exit bool) {
 		fmt.Printf("%q:\n", i.Pointer())
 		fmt.Printf("├─ valueType:  %s\n", i.ValueType().String())
 		if k := i.Key(); k != "" {

--- a/bench_test.go
+++ b/bench_test.go
@@ -31,7 +31,7 @@ type Stats struct {
 func MustCalcStatsJscan(p *jscan.Parser[[]byte], str []byte) (s Stats) {
 	if err := p.Scan(
 		str,
-		func(i *jscan.Iterator[[]byte]) (err bool) {
+		func(i *jscan.Iterator[[]byte]) (exit bool) {
 			if i.KeyIndex() != -1 {
 				// Calculate key length excluding the quotes
 				l := i.KeyIndexEnd() - i.KeyIndex() - 2

--- a/example_test.go
+++ b/example_test.go
@@ -34,7 +34,7 @@ func ExampleScan() {
 		]
 	}`
 
-	err := jscan.Scan(j, func(i *jscan.Iterator[string]) (err bool) {
+	err := jscan.Scan(j, func(i *jscan.Iterator[string]) (exit bool) {
 		fmt.Printf("%q:\n", i.Pointer())
 		fmt.Printf("├─ valueType:  %s\n", i.ValueType().String())
 		if k := i.Key(); k != "" {
@@ -157,7 +157,7 @@ func ExampleScan() {
 func ExampleScan_error_handling() {
 	j := `"something...`
 
-	err := jscan.Scan(j, func(i *jscan.Iterator[string]) (err bool) {
+	err := jscan.Scan(j, func(i *jscan.Iterator[string]) (exit bool) {
 		fmt.Println("This shall never be executed")
 		return false // No Error, resume scanning
 	})
@@ -203,7 +203,7 @@ func ExampleScan_decode2DIntArray() {
 
 	s := [][]int{}
 	currentIndex := 0
-	err := jscan.Scan(j, func(i *jscan.Iterator[string]) (err bool) {
+	err := jscan.Scan(j, func(i *jscan.Iterator[string]) (exit bool) {
 		switch i.Level() {
 		case 0: // Root array
 			return i.ValueType() != jscan.ValueTypeArray

--- a/internal/jsonnum/bench_test.go
+++ b/internal/jsonnum/bench_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func BenchmarkValid(b *testing.B) {
-	var err bool
+	var exit bool
 	for _, bb := range []string{
 		"0,",
 		"1e10,",
@@ -21,7 +21,7 @@ func BenchmarkValid(b *testing.B) {
 		b.Run("", func(b *testing.B) {
 			b.Run("string", func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
-					if _, err = jsonnum.ReadNumber(bb); err {
+					if _, exit = jsonnum.ReadNumber(bb); exit {
 						b.Fatal("unexpected error")
 					}
 				}
@@ -31,7 +31,7 @@ func BenchmarkValid(b *testing.B) {
 				bb := []byte(bb)
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
-					if _, err = jsonnum.ReadNumber(bb); err {
+					if _, exit = jsonnum.ReadNumber(bb); exit {
 						b.Fatal("unexpected error")
 					}
 				}
@@ -58,13 +58,13 @@ func BenchmarkInvalid(b *testing.B) {
 			// This err will not be checked since "01" is not technically wrong
 			// according to jsonnum.ReadNumber, it would return ("1", false) instead.
 			// All inputs are already tested in TestReadNumberErr and TestReadNumberZero.
-			var err bool
+			var exit bool
 			var remainderString string
 			var remainderBytes []byte
 
 			b.Run("string", func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
-					remainderString, err = jsonnum.ReadNumber(bb)
+					remainderString, exit = jsonnum.ReadNumber(bb)
 				}
 			})
 
@@ -72,11 +72,11 @@ func BenchmarkInvalid(b *testing.B) {
 				bb := []byte(bb)
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
-					remainderBytes, err = jsonnum.ReadNumber(bb)
+					remainderBytes, exit = jsonnum.ReadNumber(bb)
 				}
 			})
 
-			runtime.KeepAlive(err)
+			runtime.KeepAlive(exit)
 			runtime.KeepAlive(remainderString)
 			runtime.KeepAlive(remainderBytes)
 		})

--- a/internal/jsonnum/jsonnum.go
+++ b/internal/jsonnum/jsonnum.go
@@ -2,7 +2,7 @@ package jsonnum
 
 // ReadNumber returns the index of the end of the number value
 // and err=true if a syntax error was encountered.
-func ReadNumber[S ~string | ~[]byte](s S) (trailing S, err bool) {
+func ReadNumber[S ~string | ~[]byte](s S) (trailing S, exit bool) {
 	var i int
 
 	if s[0] == '-' {

--- a/jscan_test.go
+++ b/jscan_test.go
@@ -66,14 +66,14 @@ func testStrictOK[S ~string | ~[]byte](t *testing.T, input S) {
 		t.Run("Scan", func(t *testing.T) {
 			err := jscan.Scan(
 				string(input),
-				func(i *jscan.Iterator[string]) (err bool) { return false },
+				func(i *jscan.Iterator[string]) (exit bool) { return false },
 			)
 			require.False(t, err.IsErr())
 		})
 		t.Run("ScanOne", func(t *testing.T) {
 			_, err := jscan.ScanOne(
 				string(input),
-				func(i *jscan.Iterator[string]) (err bool) { return false },
+				func(i *jscan.Iterator[string]) (exit bool) { return false },
 			)
 			require.False(t, err.IsErr())
 		})
@@ -117,13 +117,13 @@ func testStrictErr[S ~string | ~[]byte](t *testing.T, input S) {
 	t.Run(testDataType(input), func(t *testing.T) {
 		t.Run("ParserScan", func(t *testing.T) {
 			err := jscan.NewParser[S](1024).Scan(
-				input, func(i *jscan.Iterator[S]) (err bool) { return false },
+				input, func(i *jscan.Iterator[S]) (exit bool) { return false },
 			)
 			require.True(t, err.IsErr())
 		})
 		t.Run("Scan", func(t *testing.T) {
 			err := jscan.Scan(
-				input, func(i *jscan.Iterator[S]) (err bool) { return false },
+				input, func(i *jscan.Iterator[S]) (exit bool) { return false },
 			)
 			require.True(t, err.IsErr())
 		})
@@ -1028,7 +1028,7 @@ func testError[S ~string | ~[]byte](t *testing.T, td ErrorTest) {
 		t.Run("Scan", func(t *testing.T) {
 			err := jscan.Scan[S](
 				S(td.input),
-				func(i *jscan.Iterator[S]) (err bool) { return false },
+				func(i *jscan.Iterator[S]) (exit bool) { return false },
 			)
 			require.Equal(t, td.expect, err.Error())
 			require.True(t, err.IsErr())
@@ -1037,7 +1037,7 @@ func testError[S ~string | ~[]byte](t *testing.T, td ErrorTest) {
 			p := jscan.NewParser[S](64)
 			err := p.Scan(
 				S(td.input),
-				func(i *jscan.Iterator[S]) (err bool) { return false },
+				func(i *jscan.Iterator[S]) (exit bool) { return false },
 			)
 			require.Equal(t, td.expect, err.Error())
 			require.True(t, err.IsErr())
@@ -1228,7 +1228,7 @@ func testControlCharacters[S ~string | ~[]byte](t *testing.T, input S, expectErr
 			p := jscan.NewParser[S](64)
 			_, err := p.ScanOne(
 				S(input),
-				func(i *jscan.Iterator[S]) (err bool) { return false },
+				func(i *jscan.Iterator[S]) (exit bool) { return false },
 			)
 			require.Equal(t, expectErr, err.Error())
 			require.True(t, err.IsErr())
@@ -1238,7 +1238,7 @@ func testControlCharacters[S ~string | ~[]byte](t *testing.T, input S, expectErr
 			p := jscan.NewParser[S](64)
 			err := p.Scan(
 				S(input),
-				func(i *jscan.Iterator[S]) (err bool) { return false },
+				func(i *jscan.Iterator[S]) (exit bool) { return false },
 			)
 			require.Equal(t, expectErr, err.Error())
 			require.True(t, err.IsErr())
@@ -1247,7 +1247,7 @@ func testControlCharacters[S ~string | ~[]byte](t *testing.T, input S, expectErr
 		t.Run("ScanOne", func(t *testing.T) {
 			_, err := jscan.ScanOne[S](
 				S(input),
-				func(i *jscan.Iterator[S]) (err bool) { return false },
+				func(i *jscan.Iterator[S]) (exit bool) { return false },
 			)
 			require.Equal(t, expectErr, err.Error())
 			require.True(t, err.IsErr())
@@ -1256,7 +1256,7 @@ func testControlCharacters[S ~string | ~[]byte](t *testing.T, input S, expectErr
 		t.Run("Scan", func(t *testing.T) {
 			err := jscan.Scan[S](
 				S(input),
-				func(i *jscan.Iterator[S]) (err bool) { return false },
+				func(i *jscan.Iterator[S]) (exit bool) { return false },
 			)
 			require.Equal(t, expectErr, err.Error())
 			require.True(t, err.IsErr())
@@ -1276,7 +1276,7 @@ func testReturnErrorTrue[S ~string | ~[]byte](t *testing.T, input S) {
 		j := 0
 		err := jscan.Scan(
 			input,
-			func(i *jscan.Iterator[S]) (err bool) {
+			func(i *jscan.Iterator[S]) (exit bool) {
 				require.Equal(t, jscan.ValueTypeObject, i.ValueType())
 				j++
 				return true // Expect immediate return
@@ -1330,7 +1330,7 @@ func testScanOne[S ~string | ~[]byte](
 		for i, c, s := 0, 1, s; len(s) > 0; c++ {
 			trailing, err := jscan.ScanOne(
 				s,
-				func(itr *jscan.Iterator[S]) (err bool) {
+				func(itr *jscan.Iterator[S]) (exit bool) {
 					require.Equal(t, expect[i], TypeValuePair{
 						Type:  itr.ValueType(),
 						Value: string(itr.Value()),
@@ -1434,7 +1434,7 @@ func testStrings[S ~string | ~[]byte](t *testing.T, input S) {
 		t.Run("ParserScan", func(t *testing.T) {
 			p := jscan.NewParser[S](64)
 			c := 0
-			err := p.Scan(inputObject, func(i *jscan.Iterator[S]) (err bool) {
+			err := p.Scan(inputObject, func(i *jscan.Iterator[S]) (exit bool) {
 				if c < 1 {
 					c++
 					return false
@@ -1451,7 +1451,7 @@ func testStrings[S ~string | ~[]byte](t *testing.T, input S) {
 			c := 0
 			trailing, err := p.ScanOne(
 				inputObject,
-				func(i *jscan.Iterator[S]) (err bool) {
+				func(i *jscan.Iterator[S]) (exit bool) {
 					if c < 1 {
 						c++
 						return false
@@ -1469,7 +1469,7 @@ func testStrings[S ~string | ~[]byte](t *testing.T, input S) {
 			c := 0
 			err := jscan.Scan[S](
 				inputObject,
-				func(i *jscan.Iterator[S]) (err bool) {
+				func(i *jscan.Iterator[S]) (exit bool) {
 					if c < 1 {
 						c++
 						return false
@@ -1486,7 +1486,7 @@ func testStrings[S ~string | ~[]byte](t *testing.T, input S) {
 			c := 0
 			trailing, err := jscan.ScanOne[S](
 				inputObject,
-				func(i *jscan.Iterator[S]) (err bool) {
+				func(i *jscan.Iterator[S]) (exit bool) {
 					if c < 1 {
 						c++
 						return false
@@ -1523,7 +1523,7 @@ func testDataType[S ~string | ~[]byte](input S) string {
 
 func TestIndexEnd(t *testing.T) {
 	c := 0
-	err := jscan.Scan(`{"x":["y"]}`, func(i *jscan.Iterator[string]) (err bool) {
+	err := jscan.Scan(`{"x":["y"]}`, func(i *jscan.Iterator[string]) (exit bool) {
 		switch c {
 		case 0:
 			require.Equal(t, jscan.ValueTypeObject, i.ValueType())

--- a/scan.go
+++ b/scan.go
@@ -21,7 +21,7 @@ import (
 //
 // WARNING: Don't use or alias *Iterator[S] after fn returns!
 func ScanOne[S ~string | ~[]byte](
-	s S, fn func(*Iterator[S]) (err bool),
+	s S, fn func(*Iterator[S]) (exit bool),
 ) (trailing S, err Error[S]) {
 	var i *Iterator[S]
 	switch any(s).(type) {
@@ -49,7 +49,7 @@ func ScanOne[S ~string | ~[]byte](
 //
 // WARNING: Don't use or alias *Iterator[S] after fn returns!
 func Scan[S ~string | ~[]byte](
-	s S, fn func(*Iterator[S]) (err bool),
+	s S, fn func(*Iterator[S]) (exit bool),
 ) (err Error[S]) {
 	var i *Iterator[S]
 	switch any(s).(type) {
@@ -108,7 +108,7 @@ func NewParser[S ~string | ~[]byte](preallocStackFrames int) *Parser[S] {
 //
 // WARNING: Don't use or alias *Iterator[S] after fn returns!
 func (p *Parser[S]) ScanOne(
-	s S, fn func(*Iterator[S]) (err bool),
+	s S, fn func(*Iterator[S]) (exit bool),
 ) (trailing S, err Error[S]) {
 	reset(p.i)
 	p.i.src = s
@@ -121,7 +121,7 @@ func (p *Parser[S]) ScanOne(
 //
 // WARNING: Don't use or alias *Iterator[S] after fn returns!
 func (p *Parser[S]) Scan(
-	s S, fn func(*Iterator[S]) (err bool),
+	s S, fn func(*Iterator[S]) (exit bool),
 ) Error[S] {
 	reset(p.i)
 	p.i.src = s
@@ -144,7 +144,7 @@ func (p *Parser[S]) Scan(
 // scan calls fn for every value encountered.
 // Returns the remainder of i.src and an error if any is encountered.
 func scan[S ~string | ~[]byte](
-	i *Iterator[S], fn func(*Iterator[S]) (err bool),
+	i *Iterator[S], fn func(*Iterator[S]) (exit bool),
 ) (S, Error[S]) {
 	var (
 		rollback S // Used as fallback for error report


### PR DESCRIPTION
renamed walker closure's named return value to `exit` instead of `err`, as considered in #21 